### PR TITLE
Fix list argument type

### DIFF
--- a/src/Schema.re
+++ b/src/Schema.re
@@ -92,7 +92,7 @@ module Arg = {
   }
   and typ(_) =
     | Object(obj('a, 'b)): typ(option('a))
-    | List(typ('a)): typ(array(option('a)))
+    | List(typ('a)): typ(option(array('a)))
     | JsInteropType(jsInteropType(_, 'src)): typ(option('src))
     | NonNull(typ(option('a))): typ('a)
     | Enum(enum('a)): typ(option('a))


### PR DESCRIPTION
Argument list type was wrapping each element of the list into an option, weather it should be the whole list that is optional, so it can properly be combined with `nonNull`, like `nonNull(list(nonNull(something)))`